### PR TITLE
Feat (closes #1) : Inaccessible Fixtures

### DIFF
--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -88,12 +88,12 @@ export async function withFixtures(
   try {
     return await fn(dir.name);
   } finally {
-    // Change back all files permissions otherwise tmp would not be allowed to delete the temp directory he has created.
-    inaccessibleFixtures.forEach((filePath: string) =>
-      fs.chmodSync(filePath, 0o777)
-    );
     process.chdir(origDir);
     if (!keep) {
+      // Change back all files permissions otherwise tmp would not be allowed to delete the temp directory he has created.
+      inaccessibleFixtures.forEach((filePath: string) =>
+        fs.chmodSync(filePath, 0o777)
+      );
       dir.removeCallback();
     }
   }

--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -88,6 +88,7 @@ export async function withFixtures(
   try {
     return await fn(dir.name);
   } finally {
+    // Change back all files permissions otherwise tmp would not be allowed to delete the temp directory he has created.
     inaccessibleFixtures.forEach((filePath: string) =>
       fs.chmodSync(filePath, 0o777)
     );


### PR DESCRIPTION
Enables FixtureContent as type for Fixtures.
 FixtureContent will create a file or directory with permission.
This will enable the consumer to test against EACCESS exceptions.
closes #1
