### PR TITLE
fix!: use a class for FixtureWithMode

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "repository": "ofrobots/inline-fixtures",
   "publishConfig": {
-    "registry": "https://wombat-dressing-room.appspot.com"
+    "registry": "https://wombat-dressing-room.appspot.com/inline-fixtures/_ns"
   },
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -21,13 +21,8 @@ import * as tmp from 'tmp';
 
 export type FixtureContent = string | Fixtures | FixtureWithMode;
 
-export interface FixtureWithMode {
-  content: string | Fixtures;
-  mode: number;
-}
-
-function isFixturesWithMode(fix: FixtureContent): fix is FixtureWithMode {
-  return 'number' === typeof (fix as FixtureWithMode).mode;
+export class FixtureWithMode {
+  constructor(readonly mode: number, readonly content: string | Fixtures) {}
 }
 
 export interface Fixtures {
@@ -50,7 +45,7 @@ export async function setupFixtures(
 
     if (typeof contents === 'string') {
       fs.writeFileSync(filePath, contents);
-    } else if (isFixturesWithMode(contents)) {
+    } else if (contents instanceof FixtureWithMode) {
       const deepinaccessibleFixtures = await setupFixtures(dir, {
         [key]: contents.content,
       });


### PR DESCRIPTION
BREAKING CHANGE: With the current nominal typing it was not possible to
have a fixture with files `mode` and `contents`. Fix this by requiring
fixtures with mode to be created via a class.