### PR TITLE
fix: do not ship source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "files": [
-    "build/src"
+    "build/src",
+    "!build/src/**/*.map"
   ],
   "engines": {
     "node": ">= 8.0.0"


### PR DESCRIPTION
Users don't have the source so map files do not help.
Instead they make the the stack traces less helpful for
users.